### PR TITLE
needed for FC7: IGNORE_SCANNING_DISABLED

### DIFF
--- a/Crate.cpp
+++ b/Crate.cpp
@@ -674,6 +674,7 @@ void Crate::ipmi_connect()
 		THROWMSG(IPMI_LibraryError, "ipmi_sensor_read_ctx_create() failed");
 	}
 	ipmi_sensor_read_ctx_set_flags(ctx.sensor_read, IPMI_SENSOR_READ_FLAGS_BRIDGE_SENSORS);
+	ipmi_sensor_read_ctx_set_flags(ctx.sensor_read, IPMI_SENSOR_READ_FLAGS_IGNORE_SCANNING_DISABLED);
 
 
 	/* Initialize SEL scanner, to not rescan old events */


### PR DESCRIPTION
with the default settings FC7 sensors can't be read: SCANNING_DISABLED flag is set. For our use case this flag can be ignored
